### PR TITLE
Use ScheduledExecutorService instead of Timer, add Futil.sleep()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for concurrent and asynchronous programming, but they can be difficult to introd
 If you're starting a green-field project then you should totally learn and use a real effect system.
 If you just need to limit the parallelism of some Futures or implement a simple Retry, you might give futil a try.
 
-## API
+## Recipes
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Effect systems and IO Monads like those provided by [cats-effect](https://typele
 for concurrent and asynchronous programming, but they can be difficult to introduce in an established codebase.
 
 If you're starting a green-field project then you should totally learn and use a real effect system.
-If you just need to limit the parallelism of some Futures or implement a simple Retry, you might give this one a try.
+If you just need to limit the parallelism of some Futures or implement a simple Retry, you might give futil a try.
 
 ## API
 
@@ -21,11 +21,14 @@ import scala.concurrent._
 import duration._
 import scala.util._
 
+// Futil imports.
+import futil._
+
+// Most methods require an implicit ExecutionContext.
 import ExecutionContext.Implicits.global
 
-// Futil imports. Some methods require an implicit java.util.Timer. We can provide our own or use this one.
-import futil._
-import Futil.Implicits.timer
+// Some methods require an implicit ScheduledExecutorService.
+import Futil.Implicits.scheduler
 
 // Let's pretend this is calling some external web service that does something useful. 
 def callService(i: Int): Future[Int] = Future(i + 1)
@@ -61,6 +64,9 @@ it will still execute eagerly and silently defeat the purpose of the whole exerc
 
 ### Timing
 
+Note that nanosecond precision is technically supported, but the overhead of scheduling, executing, etc.
+usually negates that level of precision.
+
 Time the execution of a Future.
 
 ```scala mdoc
@@ -80,6 +86,13 @@ Delay the execution of a Future.
 ```scala mdoc
 // Waits the given duration before executing the Future.
 val delayed: Future[Int] = Futil.delay(1.seconds)(callService(42))
+```
+
+Sleep asynchronously.
+
+```scala mdoc
+// Sleeps the given duration before continuing.
+val slept: Future[Unit] = Futil.sleep(1.seconds)
 ```
 
 ### Parallelism

--- a/futil/src/main/scala/futil/Futil.scala
+++ b/futil/src/main/scala/futil/Futil.scala
@@ -1,6 +1,6 @@
 package futil
 
-import java.util.concurrent.{Callable, ScheduledExecutorService, ScheduledThreadPoolExecutor}
+import java.util.concurrent.{Callable, Executors, ScheduledExecutorService}
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Try
@@ -9,7 +9,7 @@ import scala.util.Try
 object Futil {
 
   object Implicits {
-    lazy implicit val scheduler: ScheduledExecutorService = new ScheduledThreadPoolExecutor(1)
+    lazy implicit val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
   }
 
   /**

--- a/futil/src/main/scala/futil/Futil.scala
+++ b/futil/src/main/scala/futil/Futil.scala
@@ -39,8 +39,9 @@ object Futil {
   /**
     * Run the Future after delaying for the given Duration.
     */
-  final def delay[A](duration: Duration)(fa: => Future[A])(implicit ec: ExecutionContext,
-                                                           scheduler: ScheduledExecutorService): Future[A] = {
+  final def delay[A](
+      duration: Duration
+  )(fa: => Future[A])(implicit ec: ExecutionContext, scheduler: ScheduledExecutorService): Future[A] = {
     val p = Promise[A]()
     val t = new Callable[Unit] {
       override def call(): Unit = fa.onComplete(p.complete)
@@ -52,8 +53,9 @@ object Futil {
   /**
     * Asynchronously sleep for the given duration.
     */
-  final def sleep(duration: Duration)(implicit ec: ExecutionContext,
-                                      scheduler: ScheduledExecutorService): Future[Unit] =
+  final def sleep(
+      duration: Duration
+  )(implicit ec: ExecutionContext, scheduler: ScheduledExecutorService): Future[Unit] =
     delay(duration)(Future.successful(()))
 
   /**

--- a/futil/src/test/scala/futil/ParallelismSpec.scala
+++ b/futil/src/test/scala/futil/ParallelismSpec.scala
@@ -10,7 +10,7 @@ import scala.util._
 
 class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers {
 
-  import Futil.Implicits.timer
+  import Futil.Implicits.scheduler
 
   "traverseParN" - {
 

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,7 +77,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -95,11 +95,12 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
           t shouldBe Success(())
+          info(s"Completed in $duration")
           duration.toSeconds shouldBe 1
           failures.length shouldBe 5
       }
@@ -111,7 +112,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -140,7 +141,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -158,7 +159,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -174,7 +175,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -13,7 +13,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
 
   case class Expected() extends Throwable
 
-  import Futil.Implicits.timer
+  import Futil.Implicits.scheduler
   import RetryPolicy._
 
   "repeat" - {
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,7 +77,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -95,7 +95,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -111,7 +111,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -140,7 +140,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -158,7 +158,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -174,7 +174,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,7 +77,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -96,7 +96,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -113,7 +113,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -142,7 +142,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -160,7 +160,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -176,7 +176,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,7 +77,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -95,7 +95,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -111,7 +111,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -140,7 +140,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -158,7 +158,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -174,7 +174,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,11 +77,12 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
           t shouldBe Failure(Expected())
+          info(duration.toString)
           duration.toSeconds shouldBe 3
       }
     }
@@ -95,12 +96,12 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
           t shouldBe Success(())
-          info(s"Completed in $duration")
+          info(duration.toString)
           duration.toSeconds shouldBe 1
           failures.length shouldBe 5
       }
@@ -112,7 +113,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -141,7 +142,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -159,7 +160,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-        }
+      }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -175,7 +176,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-        }
+      }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -24,7 +24,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         failures.toList should have length 4
@@ -40,7 +40,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       Futil.retry(Repeat(3))(f).transformWith { t =>
         t shouldBe Success(())
         failures.length shouldBe 3
@@ -77,7 +77,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(FixedBackoff(3, 1000.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -95,7 +95,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(FixedBackoff(10, 200.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -112,7 +112,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(FixedBackoff(10, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis)
@@ -141,7 +141,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           failures.append(Expected())
           throw Expected()
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(3, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -159,7 +159,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
             failures.append(Expected())
             throw Expected()
           }
-      }
+        }
       val r = Futil.retry(ExponentialBackoff(10, 100.millis))(f)
       Futil.timed(r.transformWith(Future.successful)).flatMap {
         case (t, duration: Duration) =>
@@ -175,7 +175,7 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
         Future {
           times.append(System.nanoTime())
           throw Expected()
-      }
+        }
       Futil.retry(ExponentialBackoff(5, 100.millis))(f).transformWith { t =>
         t shouldBe Failure(Expected())
         val gaps = times.zip(times.tail).map(t => t._2 - t._1).map(_.nanos.toMillis / 100d).toVector

--- a/futil/src/test/scala/futil/ThunkSpec.scala
+++ b/futil/src/test/scala/futil/ThunkSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 
 class ThunkSpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers {
 
-  import Futil.Implicits.timer
+  import Futil.Implicits.scheduler
 
   "Thunk" - {
 

--- a/futil/src/test/scala/futil/TimingSpec.scala
+++ b/futil/src/test/scala/futil/TimingSpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{Future, TimeoutException}
 
 class TimingSpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers {
 
-  import Futil.Implicits.timer
+  import Futil.Implicits.scheduler
 
   case class Expected() extends Throwable
 
@@ -21,6 +21,16 @@ class TimingSpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers
           val dur = (System.nanoTime() - t0).nanos
           i shouldBe 99
           duration.toMillis shouldBe dur.toMillis +- 50L
+      }
+    }
+  }
+
+  "sleep" - {
+    "100 millis" in {
+      Futil.timed(Futil.sleep(100.millis)).map {
+        case (_, dur) =>
+          dur.toMillis shouldBe >=(100L)
+          dur.toMillis shouldBe <=(150L)
       }
     }
   }


### PR DESCRIPTION
`ScheduledExecutorService` seems to be the preferred way to schedule asynchronous events. Some interesting discussion here: https://stackoverflow.com/questions/409932/java-timer-vs-executorservice. The most immediate improvement for futil is that Timer could not operate on a scale more granular than milliseconds, whereas ScheduledExecutorService ostensibly can.

Also added a simple `Futil.sleep()` method.