### PR TITLE
Move earlyStop into retry method, out of policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ def earlyStop(t: Try[Int]): Future[Boolean] = t match {
   case Failure(t) => Future.successful(t.getMessage.contains("please"))
   case _          => Future.successful(false)
 }
-Futil.retry(RetryPolicy.Repeat(3, earlyStop))(() => callService(42))
+Futil.retry(RetryPolicy.Repeat(3), earlyStop)(() => callService(42))
 ```
 
 Retry with a fixed delay between calls.
@@ -142,7 +142,7 @@ Retry with a fixed delay between calls.
 Futil.retry(RetryPolicy.FixedBackoff(3, 3.seconds))(() => callService(42))
 
 // Early stop if asked nicely.
-Futil.retry(RetryPolicy.FixedBackoff(3, 3.seconds, earlyStop))(() => callService(42))
+Futil.retry(RetryPolicy.FixedBackoff(3, 3.seconds), earlyStop)(() => callService(42))
 ```
 
 Retry with exponential delay between calls.
@@ -152,7 +152,7 @@ Retry with exponential delay between calls.
 Futil.retry(RetryPolicy.ExponentialBackoff(3, 2.seconds))(() => callService(42))
 
 // Early stop if asked nicely.
-Futil.retry(RetryPolicy.ExponentialBackoff(3, 2.seconds, earlyStop))(() => callService(42))
+Futil.retry(RetryPolicy.ExponentialBackoff(3, 2.seconds), earlyStop)(() => callService(42))
 ```
 
 ### Asynchronous Semaphore (Advanced)

--- a/futil/src/main/scala/futil/RetryPolicy.scala
+++ b/futil/src/main/scala/futil/RetryPolicy.scala
@@ -1,43 +1,24 @@
 package futil
 
-import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.util.Try
 
-sealed trait RetryPolicy[T]
+sealed trait RetryPolicy
 
 object RetryPolicy {
-
-  private def earlyStopOnSuccess[T]: Try[T] => Future[Boolean] = (t: Try[T]) => Future.successful(t.isSuccess)
 
   /**
     * Retry up to n times or stop if earlyStop returns true.
     */
-  final case class Repeat[T](n: Int, earlyStop: Try[T] => Future[Boolean]) extends RetryPolicy[T]
-
-  object Repeat {
-    def apply[T](n: Int): Repeat[T] = Repeat(n, earlyStopOnSuccess)
-  }
+  final case class Repeat(n: Int) extends RetryPolicy
 
   /**
     * Retry up to n times, delaying by duration between each try. Stop if earlyStop returns true.
     */
-  final case class FixedBackoff[T](n: Int, duration: Duration, earlyStop: Try[T] => Future[Boolean])
-      extends RetryPolicy[T]
-
-  object FixedBackoff {
-    def apply[T](n: Int, duration: Duration): FixedBackoff[T] = FixedBackoff(n, duration, earlyStopOnSuccess)
-  }
+  final case class FixedBackoff(n: Int, duration: Duration) extends RetryPolicy
 
   /**
     * Retry up to n times, doubling the initial duration between each try. Stop if earlyStop returns true.
     */
-  final case class ExponentialBackoff[T](n: Int, duration: Duration, earlyStop: Try[T] => Future[Boolean])
-      extends RetryPolicy[T]
-
-  object ExponentialBackoff {
-    def apply[T](n: Int, duration: Duration): ExponentialBackoff[T] =
-      ExponentialBackoff(n, duration, earlyStopOnSuccess)
-  }
+  final case class ExponentialBackoff(n: Int, duration: Duration) extends RetryPolicy
 
 }

--- a/futil/src/test/scala/futil/RetrySpec.scala
+++ b/futil/src/test/scala/futil/RetrySpec.scala
@@ -60,8 +60,8 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
       var counter = 0
       val f = () => Future.failed { counter += 1; Expected() }
       val decision = (_: Try[Unit]) => Future.successful(counter >= 10)
-      val policy = Repeat(99, decision)
-      Futil.retry(policy)(f).transformWith { t =>
+      val policy = Repeat(99)
+      Futil.retry(policy, decision)(f).transformWith { t =>
         t shouldBe Failure(Expected())
         counter shouldBe 10
       }
@@ -125,8 +125,8 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
       var counter = 0
       val f = () => Future.failed { counter += 1; Expected() }
       val decision = (_: Try[Unit]) => Future.successful(counter >= 10)
-      val policy = FixedBackoff(99, 100.millis, decision)
-      Futil.retry(policy)(f).transformWith { t =>
+      val policy = FixedBackoff(99, 100.millis)
+      Futil.retry(policy, decision)(f).transformWith { t =>
         t shouldBe Failure(Expected())
         counter shouldBe 10
       }
@@ -191,8 +191,8 @@ class RetrySpec extends AsyncFreeSpec with GlobalExecutionContext with Matchers 
       var counter = 0
       val f = () => Future.failed { counter += 1; Expected() }
       val decision = (_: Try[Unit]) => Future.successful(counter >= 10)
-      val policy = ExponentialBackoff(99, 2.millis, decision)
-      Futil.retry(policy)(f).transformWith { t =>
+      val policy = ExponentialBackoff(99, 2.millis)
+      Futil.retry(policy, decision)(f).transformWith { t =>
         t shouldBe Failure(Expected())
         counter shouldBe 10
       }


### PR DESCRIPTION
This moves the retry method out of three places in the RetryPolicy and into one place in the retry method. Also gets rid of the need for a type parameter in the RetryPolicy.