### PR TITLE
Remove Try from traverseParN and traverseSerial

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ val numInParallel = 16
 val inputs: Seq[Int] = 0 to 9999
 def f(i: Int): Future[Double] = callService(i).map(_ * 3.14)
 
-// Returns a Seq[Try[...]], indicating that some of the calls might have failed. 
-val outputs: Future[Seq[Try[Double]]] = Futil.traverseParN(numInParallel)(inputs)(f)
+// This has the same type signature as Future.traverse. 
+val outputs: Future[Seq[Double]] = Futil.traverseParN(numInParallel)(inputs)(f)
 ```
 
 Run a Future for every item in a Seq, exactly one at a time.
 
 ```scala mdoc
-val outputsSerial: Future[Seq[Try[Double]]] = Futil.traverseSerial(inputs)(f)
+val outputsSerial: Future[Seq[Double]] = Futil.traverseSerial(inputs)(f)
 ```
 
 ### Retries

--- a/futil/src/main/scala/futil/Futil.scala
+++ b/futil/src/main/scala/futil/Futil.scala
@@ -73,7 +73,6 @@ object Futil {
 
   /**
     * Use function f to map each element from `in` to a Future[B], running at most n Futures at a time.
-    * Lifts the result of the Future[B] into a Future[Try[B]\] to prevent failing the entire Seq.
     * Results are returned in the original order.
     */
   final def traverseParN[A, B, M[X] <: IterableOnce[X]](

--- a/futil/src/main/scala/futil/Futil.scala
+++ b/futil/src/main/scala/futil/Futil.scala
@@ -80,11 +80,11 @@ object Futil {
       n: Int
   )(
       in: M[A]
-  )(fn: A => Future[B])(implicit bf: BuildFrom[M[A], Try[B], M[Try[B]]], ec: ExecutionContext): Future[M[Try[B]]] = {
+  )(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Future[M[B]] = {
     val sem = semaphore(n)
     in.iterator
       .foldLeft(successful(bf.newBuilder(in))) { (f1, a: A) =>
-        val f2 = sem.withPermit(thunk(fn(a).transformWith(Future.successful)))
+        val f2 = sem.withPermit(thunk(fn(a)))
         f1.zipWith(f2)(_ += _)
       }
       .map(_.result())(ec)
@@ -95,7 +95,7 @@ object Futil {
     */
   final def traverseSerial[A, B, M[X] <: IterableOnce[X]](
       in: M[A]
-  )(fn: A => Future[B])(implicit bf: BuildFrom[M[A], Try[B], M[Try[B]]], ec: ExecutionContext): Future[M[Try[B]]] =
+  )(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Future[M[B]] =
     traverseParN(1)(in)(fn)
 
   /**

--- a/futil/src/test/scala/futil/ParallelismSpec.scala
+++ b/futil/src/test/scala/futil/ParallelismSpec.scala
@@ -18,7 +18,7 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
       val as = (1 to 1000).toVector
       val f = (i: Int) => Future.successful(i)
       Futil.traverseParN(10)(as)(f).flatMap { bs =>
-        bs shouldBe as.map(Success(_))
+        bs shouldBe as
       }
     }
 
@@ -26,7 +26,7 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
       final case class Expected(i: Int) extends Throwable
       val as = (1 to 1000).toVector
       val f = (i: Int) => Future.failed[Int](Expected(i))
-      Futil.traverseParN(10)(as)(f).flatMap { bs =>
+      Futil.traverseParN(10)(as)(f(_).transformWith(Future.successful)).flatMap { bs =>
         bs shouldBe as.map(Expected).map(Failure(_))
       }
     }
@@ -35,7 +35,7 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
       final case class Expected(i: Int) extends Throwable
       val as = (1 to 1000).toVector
       val f = (i: Int) => if (i % 2 == 0) Future.successful(i) else Future.failed(Expected(i))
-      Futil.traverseParN(10)(as)(f).flatMap { bs =>
+      Futil.traverseParN(10)(as)(f(_).transformWith(Future.successful)).flatMap { bs =>
         bs shouldBe as.map(i => if (i % 2 == 0) Success(i) else Failure(Expected(i)))
       }
     }

--- a/futil/src/test/scala/futil/ParallelismSpec.scala
+++ b/futil/src/test/scala/futil/ParallelismSpec.scala
@@ -56,7 +56,7 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
           }
         } yield i
 
-      Futil.traverseParN(n)(as)(f).flatMap { bs =>
+      Futil.traverseParN(n)(as)(f(_).transformWith(Future.successful)).flatMap { bs =>
         bs.filter(_.isFailure) shouldBe Seq.empty
       }
     }
@@ -103,9 +103,9 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
     }
 
     "1 million mixed delays and fibonaccis" in {
-      val as = (0 to 999999)
+      val as: Seq[Int] = (0 to 999999)
       val f = (i: Int) =>
-        if (i % 2 == 0) Future(fib(i % 28)) else Futil.delay((i % 30000 + 10000).nanos)(Future.successful(()))
+        if (i % 2 == 0) Future(fib(i % 28)) else Futil.delay((i % 30000 + 10000).nanos)(Future.successful(i))
       Futil.traverseParN(2)(as)(f).flatMap(_.toVector.length shouldBe as.length)
     }
 
@@ -128,7 +128,7 @@ class ParallelismSpec extends AsyncFreeSpec with GlobalExecutionContext with Mat
           }
         } yield i
 
-      Futil.traverseSerial(as)(f).flatMap { bs =>
+      Futil.traverseSerial(as)(f(_).transformWith(Future.successful)).flatMap { bs =>
         bs.filter(_.isFailure) shouldBe Seq.empty
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.1-PRE4-SNAPSHOT"
+ThisBuild / version := "0.1.2-PRE0-SNAPSHOT"


### PR DESCRIPTION
It's nicer for it to have the same type signature as Future.traverse. If you really need the Try, you can easily use `.recoverWith(Future.successful)`.